### PR TITLE
chore: Try dropping the /u/0 again

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/u/0/folders/1gA2WOuzPbLDy2mVkM_f42K3jzrZrn9Td
+  /: https://drive.google.com/drive/folders/1gA2WOuzPbLDy2mVkM_f42K3jzrZrn9Td


### PR DESCRIPTION
The folder is definitely shared with helix@adobe.com though I'm trying again with the content using "... > Make a Copy" then "Organise > Move to (folder shared with Adobe) and also renaming each file accordingly".

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
