### PR TITLE
style: Try more contrasting link and background colours

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,7 +12,7 @@
 
  :root {
   /* colors */
-  --link-color: #0000ff;
+  --link-color: #00f;
   --link-hover-color: #0020ff;
   --background-color: #fff;
   --overlay-background-color: #eee;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -131,7 +131,7 @@ main pre {
 
 a:any-link {
   color: var(--link-color);
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 a:hover {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,11 +12,11 @@
 
  :root {
   /* colors */
-  --link-color: #0050ff;
+  --link-color: #0000ff;
   --link-hover-color: #0020ff;
   --background-color: #fff;
   --overlay-background-color: #eee;
-  --highlight-background-color: #ccc;
+  --highlight-background-color: #e8e8e8;
   --text-color: #000;
 
   /* fonts */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,8 +12,8 @@
 
  :root {
   /* colors */
-  --link-color: #035fe6;
-  --link-hover-color: #136ff6;
+  --link-color: #0050ff;
+  --link-hover-color: #0020ff;
   --background-color: #fff;
   --overlay-background-color: #eee;
   --highlight-background-color: #ccc;


### PR DESCRIPTION
Goal is to see if after increases the a11y score.

https://dequeuniversity.com/rules/axe/4.7/color-contrast is great!

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
