### PR TITLE
a11y: Add iconName to img.alt

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -395,7 +395,7 @@ function decorateButtons(element) {
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
- * @param {span} [element] span element with icon classes
+ * @param {span} [span] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
 function decorateIcon(span, prefix = '') {
@@ -404,6 +404,7 @@ function decorateIcon(span, prefix = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
+  img.alt = `${iconName} icon`;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
   img.loading = 'lazy';
   span.append(img);


### PR DESCRIPTION
There doesn't seem to be another obvious place to plug in metadata about the icons, so this seems quite reasonable.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
