### PR TITLE
chore: remove useless dependencies (#290)

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -21,5 +21,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run semantic-release
-      - name: Show working copy
-        run: ls -la && git status

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.27.5",
     "semantic-release": "21.0.5",
-    "sinon": "15.0.1",
     "stylelint": "15.2.0",
     "stylelint-config-standard": "30.0.1"
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/adobe/aem-boilerplate/commit/5613d518273383269f3505a81751d080a9652062 Merge conflicts due to my accepting npm's auto-sort of dependencies, while upstream at Adobe they've chosen to keep all the semantic-release ones paired together.

Plus also I removed some other ones in #11.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
