### PR TITLE
a11y: Explore possibly better fix for icons

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -395,7 +395,7 @@ function decorateButtons(element) {
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
- * @param {span} [span] span element with icon classes
+ * @param {Element} [span] span element with icon classes
  * @param {string} [prefix] prefix to be added to icon the src
  */
 function decorateIcon(span, prefix = '') {
@@ -404,7 +404,7 @@ function decorateIcon(span, prefix = '') {
     .substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
-  img.alt = `${iconName} icon`;
+  img.setAttribute('role', 'presentation');
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
   img.loading = 'lazy';
   span.append(img);


### PR DESCRIPTION
Upstream discussion: https://github.com/adobe/aem-boilerplate/pull/280

Looking in Google Docs, there's no easy or obvious way I can see to add the alt text in for icon text, unlike for images where it can be in one of two `Image Options` places quite happily - the official `Alt text > Description` field, or the `Alt text > Advanced options` field.

There's also no obvious way for a developer/engineer to configure the alt text for a specific icon. So perhaps it's better left out?

[Convention over configuration](https://en.wikipedia.org/wiki/Convention_over_configuration) probably adds more trouble, it'd require a configuration convention like another yaml or json file (the repo currently takes both sides, e.g. fstab.yaml vs package.json) which could be subject to the [hot-spot problem](https://kousiknath.medium.com/all-things-sharding-techniques-and-real-life-examples-in-nosql-data-storage-systems-3e8beb98830a) and  so guarantee merge conflicts on larger projects...

Basically I don't think there's any easy and configurable answer here because who, where and how to configure it are not obvious to me at least. 

So [role: presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) makes the most sense for the built-in version, and perhaps some other mechanism for non-presentation roles will become more obvious. 

Plus `role:presention` feels closer to [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle), i.e. probably the right direction.

Not sure why anyone would want to read my braindump, but if you did, thanks for reading.

----

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
