### PR TITLE
lint: Remove redundant lint comments

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -59,7 +59,6 @@ function sampleRUM(checkpoint, data = {}) {
         origin: () => window.location.origin,
         path: () => window.location.href.replace(/\?.*$/, ''),
       };
-      // eslint-disable-next-line object-curly-newline, max-len
       window.hlx.rum = {
         weight,
         id,
@@ -87,7 +86,6 @@ function sampleRUM(checkpoint, data = {}) {
         'INP',
       ];
       const sendPing = (pdata = data) => {
-        // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
         const body = JSON.stringify(
           {
             weight,
@@ -100,7 +98,6 @@ function sampleRUM(checkpoint, data = {}) {
           knownProperties,
         );
         const url = `https://rum.hlx.page/.rum/${weight}`;
-        // eslint-disable-next-line no-unused-expressions
         navigator.sendBeacon(url, body);
         // eslint-disable-next-line no-console
         console.debug(`ping:${checkpoint}`, pdata);
@@ -196,7 +193,6 @@ function toCamelCase(name) {
  * @param {Element} block The block element
  * @returns {object} The block config
  */
-// eslint-disable-next-line import/prefer-default-export
 function readBlockConfig(block) {
   const config = {};
   block.querySelectorAll(':scope > div').forEach((row) => {
@@ -466,7 +462,6 @@ function decorateSections(main) {
  * @param {string} [prefix] Location of placeholders
  * @returns {object} Window placeholders object
  */
-// eslint-disable-next-line import/prefer-default-export
 async function fetchPlaceholders(prefix = 'default') {
   window.placeholders = window.placeholders || {};
   if (!window.placeholders[prefix]) {

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-cycle
 import { sampleRUM } from './aem.js';
 
 // Core Web Vitals RUM collection

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -121,7 +121,6 @@ async function loadLazy(doc) {
  * without impacting the user experience.
  */
 function loadDelayed() {
-  // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);
   // load anything that can be postponed to the latest here
 }


### PR DESCRIPTION
There are still others like `no-console` which make sense, so they have been left in.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate--pzrq.hlx.page/
- After: https://develop--aem-boilerplate--pzrq.hlx.page/
